### PR TITLE
Autofix: linux下通过faq里的教程通过steam设置XLM兼容层运行闪退

### DIFF
--- a/src/XIVLauncher.Common.Unix/UnixGameRunner.cs
+++ b/src/XIVLauncher.Common.Unix/UnixGameRunner.cs
@@ -22,6 +22,32 @@ public class UnixGameRunner : IGameRunner
 
     public Process? Start(string path, string workingDirectory, string arguments, IDictionary<string, string> environment, DpiAwareness dpiAwareness)
     {
+        var isSteam = environment.ContainsKey("SteamAppId");
+
+        if (isSteam)
+        {
+            // For Steam, we need to use the compatibility tool's run command
+            var steamCompatToolPath = environment["STEAM_COMPAT_CLIENT_INSTALL_PATH"];
+            var steamCompatToolCommand = Path.Combine(steamCompatToolPath, "steamclient.so");
+
+            var processStartInfo = new ProcessStartInfo
+            {
+                FileName = steamCompatToolCommand,
+                Arguments = $"\"{path}\" {arguments}",
+                WorkingDirectory = workingDirectory,
+                UseShellExecute = false
+            };
+
+            foreach (var envVar in environment)
+            {
+                processStartInfo.EnvironmentVariables[envVar.Key] = envVar.Value;
+            }
+
+            return Process.Start(processStartInfo);
+        }
+
+        // Non-Steam launch process
+        if (dalamudOk)
         if (dalamudOk)
         {
             return this.dalamudLauncher.Run(new FileInfo(path), arguments, environment);


### PR DESCRIPTION
Modify the UnixGameRunner class to handle Steam-specific launching requirements. This change adds a check for the Steam environment and modifies the launch process accordingly. 
> [!CAUTION]
> Disclaimer: This fix was created by Latta AI and you should never merge before you check the correctness of generated code!
>
> The fix provided by Latta AI might not be complete and it can serve as an inspiration.

---
This bug was fixed for free by Latta AI - https://latta.ai/ourmission

If you no longer want Latta AI to attempt fixing issues on your repository, you can block this account.
    